### PR TITLE
fix: FindWithOpt のカナ結合ループでトークン配列が破損するバグを修正

### DIFF
--- a/haiku.go
+++ b/haiku.go
@@ -258,14 +258,11 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 					break
 				}
 			}
-			tokens[i].Surface = surface
-			for k := 0; k < (j - i); k++ {
-				if i+1+k < len(tokens) && j+k < len(tokens) {
-					tokens[i+1+k] = tokens[j+k]
-				}
+			if j > i+1 {
+				tokens[i].Surface = surface
+				copy(tokens[i+1:], tokens[j:])
+				tokens = tokens[:len(tokens)-(j-i-1)]
 			}
-			tokens = tokens[:len(tokens)-(j-i)+1]
-			i = j
 		}
 	}
 

--- a/haiku_test.go
+++ b/haiku_test.go
@@ -40,3 +40,65 @@ func TestHaiku(t *testing.T) {
 	testMatch(t, "testdata/tanka.good", []int{5, 7, 5, 7, 7}, true)
 	testMatch(t, "testdata/tanka.bad", []int{5, 7, 5, 7, 7}, false)
 }
+
+func TestFindWithOpt_KatakanaBeforeTextShouldNotCorruptTokens(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// カタカナが先行する文でトークン配列が破損し、
+	// 存在しない俳句が検出されていたバグの再現テスト
+	// Refs: u16-io/FindSenryu4Discord#66
+	text := "ヤメ、ヤメ、ヤメロ!!  冷静の国境線を越えて　攻めて来るぞ"
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range result {
+		// 破損したトークン配列から生成された "国境の" のような
+		// 原文に存在しない部分文字列が含まれていないことを確認
+		normalized := strings.ReplaceAll(s, " ", "")
+		if !containsSubstring(text, normalized) {
+			t.Errorf("found sentence %q is not a substring of original text %q", s, text)
+		}
+	}
+}
+
+func TestFindWithOpt_TextWithoutKatakanaShouldWorkNormally(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// カタカナなしの同じ後半部分は正常に動作すべき
+	text := "冷静の国境線を越えて　攻めて来るぞ"
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range result {
+		normalized := strings.ReplaceAll(s, " ", "")
+		if !containsSubstring(text, normalized) {
+			t.Errorf("found sentence %q is not a substring of original text %q", s, text)
+		}
+	}
+}
+
+func TestFindWithOpt_ConsecutiveKatakanaMergedCorrectly(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// カタカナのみの入力でパニックしないことを確認
+	text := "アイウエオカキクケコサシスセソ"
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = result // パニックしなければOK
+}
+
+// containsSubstring は text に sub が含まれるかを確認する。
+// 句読点・空白・記号を除去した上で比較する。
+func containsSubstring(text, sub string) bool {
+	cleanText := reIgnoreText.ReplaceAllString(text, "")
+	cleanText = strings.ReplaceAll(cleanText, " ", "")
+	cleanText = strings.ReplaceAll(cleanText, "　", "")
+	return strings.Contains(cleanText, sub)
+}


### PR DESCRIPTION
## Summary

- `FindWithOpt` のカタカナトークン結合ループで、シフト処理が不完全かつインデックス制御が不正だったため、トークン配列に重複が発生し、原文に存在しない "俳句" が検出されていたバグを修正
- シフト処理を `copy()` に置換し、不要な `i = j` を削除
- 再現テスト3件を追加

## 原因

カナ結合ループ（旧250-269行目）に2つのバグ:

1. シフトループが `j-i` 個しかコピーせず、残りのトークンが移動されなかった → トークン配列に重複が発生
2. `i = j` で圧縮後の配列に対して不正な位置にジャンプ → 後続トークンがスキップ

例: 「ヤメ、ヤメ、ヤメロ!! 冷静の国境線を越えて 攻めて来るぞ」で「国境の 国境線を 越えて攻め」という原文に存在しない文が検出されていた。

## Test plan

- [x] 既存テスト (TestHaiku) がパスすることを確認
- [x] Issue #66 の再現テストがパスすることを確認
- [x] カタカナのみの入力でパニックしないことを確認

Refs: u16-io/FindSenryu4Discord#66

🤖 Generated with [Claude Code](https://claude.com/claude-code)