### PR TITLE
fix: カタカナ検出の複数バグ修正と半角対応

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	golang.org/x/net v0.19.0
 )
 
-require golang.org/x/text v0.14.0 // indirect
+require golang.org/x/text v0.14.0

--- a/haiku.go
+++ b/haiku.go
@@ -6,16 +6,20 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/ikawaha/kagome-dict/dict"
 	"github.com/ikawaha/kagome/v2/tokenizer"
+	"golang.org/x/text/unicode/norm"
+	"golang.org/x/text/width"
 )
 
 var (
 	reWord       = regexp.MustCompile(`^[ァ-ヾ]+$`)
-	reIgnoreText = regexp.MustCompile(`[\[\]「」『』、。？！]`)
+	reIgnoreText = regexp.MustCompile(`[\[\]［］「」『』、。？！]`)
 	reIgnoreChar = regexp.MustCompile(`[ァィゥェォャュョ]`)
-	reKana       = regexp.MustCompile(`^[ァ-タダ-ヶ]+$`)
+	reKana       = regexp.MustCompile(`^[ァ-ヶー]+$`)
 
 	globalDict *dict.Dict
 )
@@ -123,6 +127,74 @@ func countChars(s string) int {
 	return len([]rune(reIgnoreChar.ReplaceAllString(s, "")))
 }
 
+// normalizeText normalizes half-width katakana to full-width and applies NFC.
+// Returns the normalized text and a rune-index mapping where nfcToOrig[i]
+// is the rune index in original text corresponding to rune i in normalized text.
+func normalizeText(orig string) (string, []int) {
+	widened := width.Widen.String(orig)
+	normalized := norm.NFC.String(widened)
+
+	wideRunes := []rune(widened)
+	nfcRunes := []rune(normalized)
+
+	nfcToOrig := make([]int, len(nfcRunes)+1)
+	wi := 0
+	for ni := 0; ni < len(nfcRunes); ni++ {
+		nfcToOrig[ni] = wi
+		if wi < len(wideRunes) && wideRunes[wi] == nfcRunes[ni] {
+			wi++
+		} else {
+			wi++ // base character
+			for wi < len(wideRunes) && unicode.Is(unicode.Mn, wideRunes[wi]) {
+				wi++
+			}
+		}
+	}
+	nfcToOrig[len(nfcRunes)] = wi
+
+	return normalized, nfcToOrig
+}
+
+// splitUnknownKatakana splits an unknown katakana token into known sub-tokens
+// using longest-match-first strategy. This handles cases where Kagome merges
+// known and unknown katakana into a single unknown token (e.g. "テストミミッキュ").
+func splitUnknownKatakana(t *tokenizer.Tokenizer, surface string) []tokenizer.Token {
+	runes := []rune(surface)
+	if len(runes) <= 1 {
+		return nil
+	}
+	var result []tokenizer.Token
+	pos := 0
+	for pos < len(runes) {
+		bestLen := 1
+		var bestToken *tokenizer.Token
+		for end := len(runes); end > pos+1; end-- {
+			prefix := string(runes[pos:end])
+			tokens := t.Tokenize(prefix)
+			if len(tokens) > 0 && len(tokens[0].Features()) >= 7 {
+				tl := utf8.RuneCountInString(tokens[0].Surface)
+				tok := tokens[0]
+				bestToken = &tok
+				bestLen = tl
+				break
+			}
+		}
+		if bestToken != nil {
+			result = append(result, *bestToken)
+		} else {
+			tokens := t.Tokenize(string(runes[pos : pos+1]))
+			if len(tokens) > 0 {
+				result = append(result, tokens[0])
+			}
+		}
+		pos += bestLen
+	}
+	if len(result) <= 1 {
+		return nil
+	}
+	return result
+}
+
 // Match return true when text matches with rule(s).
 func Match(text string, rule []int) bool {
 	return MatchWithOpt(text, rule, &Opt{})
@@ -148,6 +220,7 @@ func MatchWithOpt(text string, rule []int, opt *Opt) bool {
 	if err != nil {
 		return false
 	}
+	text = norm.NFC.String(width.Widen.String(text))
 	text = reIgnoreText.ReplaceAllString(text, " ")
 	tokens := t.Tokenize(text)
 	pos := 0
@@ -162,6 +235,19 @@ func MatchWithOpt(text string, rule []int, opt *Opt) bool {
 		}
 	}
 	tokens = tmp
+
+	// Split unknown katakana tokens into known sub-tokens
+	for i := 0; i < len(tokens); i++ {
+		if reKana.MatchString(tokens[i].Surface) && len(tokens[i].Features()) < 7 {
+			if sub := splitUnknownKatakana(t, tokens[i].Surface); len(sub) > 0 {
+				expanded := make([]tokenizer.Token, 0, len(tokens)+len(sub)-1)
+				expanded = append(expanded, tokens[:i]...)
+				expanded = append(expanded, sub...)
+				expanded = append(expanded, tokens[i+1:]...)
+				tokens = expanded
+			}
+		}
+	}
 
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
@@ -229,8 +315,22 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	text = reIgnoreText.ReplaceAllString(text, " ")
-	tokens := t.Tokenize(text)
+	origRunes := []rune(text)
+	normText, nfcToOrig := normalizeText(text)
+	normText = reIgnoreText.ReplaceAllString(normText, " ")
+	tokens := t.Tokenize(normText)
+
+	// Build original surfaces using rune mapping
+	origSurfaces := make([]string, len(tokens))
+	runePos := 0
+	for i, tok := range tokens {
+		tokRuneLen := utf8.RuneCountInString(tok.Surface)
+		origStart := nfcToOrig[runePos]
+		origEnd := nfcToOrig[runePos+tokRuneLen]
+		origSurfaces[i] = string(origRunes[origStart:origEnd])
+		runePos += tokRuneLen
+	}
+
 	pos := 0
 	r := make([]int, len(rule))
 	copy(r, rule)
@@ -238,30 +338,71 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 	start := 0
 	ambigous := 0
 
-	var tmp []tokenizer.Token
-	for _, token := range tokens {
+	// Filter ignored tokens (keep origSurfaces in sync)
+	var filteredTokens []tokenizer.Token
+	var filteredOrig []string
+	for i, token := range tokens {
 		c := token.Features()
 		if !isIgnore(d, c) {
-			tmp = append(tmp, token)
+			filteredTokens = append(filteredTokens, token)
+			filteredOrig = append(filteredOrig, origSurfaces[i])
 		}
 	}
-	tokens = tmp
+	tokens = filteredTokens
+	origSurfaces = filteredOrig
 
+	// Merge consecutive unknown katakana, then split into known sub-tokens
 	for i := 0; i < len(tokens); i++ {
-		if reKana.MatchString(tokens[i].Surface) {
+		if reKana.MatchString(tokens[i].Surface) && len(tokens[i].Features()) < 7 {
+			// Merge consecutive unknown katakana
 			surface := tokens[i].Surface
+			origSurf := origSurfaces[i]
 			var j int
 			for j = i + 1; j < len(tokens); j++ {
-				if reKana.MatchString(tokens[j].Surface) {
+				if reKana.MatchString(tokens[j].Surface) && len(tokens[j].Features()) < 7 {
 					surface += tokens[j].Surface
+					origSurf += origSurfaces[j]
 				} else {
 					break
 				}
 			}
 			if j > i+1 {
 				tokens[i].Surface = surface
+				origSurfaces[i] = origSurf
 				copy(tokens[i+1:], tokens[j:])
 				tokens = tokens[:len(tokens)-(j-i-1)]
+				copy(origSurfaces[i+1:], origSurfaces[j:])
+				origSurfaces = origSurfaces[:len(origSurfaces)-(j-i-1)]
+			}
+
+			// Split merged unknown katakana into known sub-tokens
+			if sub := splitUnknownKatakana(t, tokens[i].Surface); len(sub) > 0 {
+				// Build sub-origSurfaces using local rune mapping
+				parentOrigSurf := origSurfaces[i]
+				_, localMap := normalizeText(parentOrigSurf)
+				parentOrigRunes := []rune(parentOrigSurf)
+				subOrig := make([]string, len(sub))
+				localRunePos := 0
+				for si, st := range sub {
+					stRuneLen := utf8.RuneCountInString(st.Surface)
+					origStart := localMap[localRunePos]
+					origEnd := localMap[localRunePos+stRuneLen]
+					subOrig[si] = string(parentOrigRunes[origStart:origEnd])
+					localRunePos += stRuneLen
+				}
+
+				// Splice into tokens and origSurfaces
+				newTokens := make([]tokenizer.Token, 0, len(tokens)+len(sub)-1)
+				newTokens = append(newTokens, tokens[:i]...)
+				newTokens = append(newTokens, sub...)
+				newTokens = append(newTokens, tokens[i+1:]...)
+				tokens = newTokens
+
+				newOrig := make([]string, 0, len(origSurfaces)+len(subOrig)-1)
+				newOrig = append(newOrig, origSurfaces[:i]...)
+				newOrig = append(newOrig, subOrig...)
+				newOrig = append(newOrig, origSurfaces[i+1:]...)
+				origSurfaces = newOrig
 			}
 		}
 	}
@@ -270,7 +411,7 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
 		c := tok.Features()
-		if len(c) < 7 {
+		if len(c) < 7 && !reKana.MatchString(tok.Surface) {
 			continue
 		}
 		var y string
@@ -304,7 +445,7 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 		ambigous += strings.Count(y, "ッ") + strings.Count(y, "ー")
 		n := countChars(y)
 		r[pos] -= n
-		sentence += tok.Surface
+		sentence += origSurfaces[i]
 		if r[pos] >= 0 && (r[pos] == 0 || r[pos]+ambigous == 0) {
 			pos++
 			if pos == len(r) || pos == len(r)+1 {

--- a/haiku_test.go
+++ b/haiku_test.go
@@ -94,6 +94,129 @@ func TestFindWithOpt_ConsecutiveKatakanaMergedCorrectly(t *testing.T) {
 	_ = result // パニックしなければOK
 }
 
+func TestFindWithOpt_KatakanaOnlyHaikuShouldBeDetected(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// カタカナ語を含む俳句が正しく検出されることを確認
+	text := "クリスマスケーキを食べるプレゼント"
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Errorf("expected haiku to be found in %q, got none", text)
+	}
+
+	if !MatchWithOpt(text, []int{5, 7, 5}, opts) {
+		t.Errorf("expected %q to match 5-7-5", text)
+	}
+}
+
+func TestFindWithOpt_HalfWidthKatakanaShouldBeNormalized(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// 半角カタカナが全角に正規化されて検出されることを確認
+	fullWidth := "クリスマスケーキを食べるプレゼント"
+	halfWidth := "ｸﾘｽﾏｽｹｰｷを食べるﾌﾟﾚｾﾞﾝﾄ"
+	mixed := "ｸﾘｽﾏｽケーキを食べるプレゼント"
+
+	for _, text := range []string{fullWidth, halfWidth, mixed} {
+		result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", text, err)
+		}
+		if len(result) == 0 {
+			t.Errorf("expected haiku to be found in %q, got none", text)
+		}
+		if !MatchWithOpt(text, []int{5, 7, 5}, opts) {
+			t.Errorf("expected %q to match 5-7-5", text)
+		}
+	}
+}
+
+func TestFindWithOpt_OriginalSurfaceShouldBePreserved(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// 検出結果が入力テキストの元の表記（半角/全角）を保持することを確認
+	cases := []struct {
+		text    string
+		wantSub string
+	}{
+		{"クリスマスケーキを食べるプレゼント", "クリスマス"},
+		{"ｸﾘｽﾏｽｹｰｷを食べるﾌﾟﾚｾﾞﾝﾄ", "ｸﾘｽﾏｽ"},
+		{"ｸﾘｽﾏｽケーキを食べるプレゼント", "ｸﾘｽﾏｽ"},
+	}
+	for _, c := range cases {
+		result, err := FindWithOpt(c.text, []int{5, 7, 5}, opts)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", c.text, err)
+		}
+		if len(result) == 0 {
+			t.Fatalf("expected haiku to be found in %q, got none", c.text)
+		}
+		if !strings.Contains(result[0], c.wantSub) {
+			t.Errorf("expected result %q to contain %q", result[0], c.wantSub)
+		}
+	}
+}
+
+func TestFindWithOpt_UnknownKatakanaShouldNotBeSkipped(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// 辞書に存在しないカタカナ語（features < 7）がスキップされ、
+	// 偽陽性の俳句が検出されるバグの再現テスト
+	text := "検出のテスト投稿ミミッキュ検出だ"
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range result {
+		normalized := strings.ReplaceAll(s, " ", "")
+		if !strings.Contains(text, normalized) {
+			t.Errorf("found sentence %q is not a substring of original text %q", s, text)
+		}
+		if !strings.Contains(normalized, "ミミッキュ") && strings.Contains(normalized, "テスト投稿検出") {
+			t.Errorf("ミミッキュ was skipped, producing false positive: %q", s)
+		}
+	}
+}
+
+func TestFindWithOpt_KagomeMergedKatakanaShouldBeSplit(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// Kagome が既知+未知カタカナを1トークンに結合するケースで
+	// 正しく分割されることを確認
+	text := "検出のテスト投稿ミミッキュ検出だ"
+	result, _ := FindWithOpt(text, []int{5, 7, 5}, opts)
+	for _, s := range result {
+		normalized := strings.ReplaceAll(s, " ", "")
+		if !strings.Contains(text, normalized) {
+			t.Errorf("result %q is not a substring of %q", normalized, text)
+		}
+	}
+}
+
+func TestMatchWithOpt_FullwidthBracketsIgnored(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// ASCII/全角ブラケットが正しく無視されることを確認
+	for _, text := range []string{
+		"[古池や]蛙飛び込む水の音",
+		"［古池や］蛙飛び込む水の音",
+		"「古池や」蛙飛び込む水の音",
+	} {
+		if !MatchWithOpt(text, []int{5, 7, 5}, opts) {
+			t.Errorf("expected %q to match 5-7-5", text)
+		}
+	}
+}
+
 // containsSubstring は text に sub が含まれるかを確認する。
 // 句読点・空白・記号を除去した上で比較する。
 func containsSubstring(text, sub string) bool {


### PR DESCRIPTION
## Summary
- 未知カタカナ語（`ミミッキュ` 等）が `FindWithOpt` でスキップされ偽陽性の俳句が検出されるバグを修正
- 半角カタカナ（`ｸﾘｽﾏｽ` 等）に対応し、全半角問わず俳句を検出可能に
- `FindWithOpt` の結果が入力テキストの元の表記（半角/全角）を保持するよう改善
- `reIgnoreText` に全角ブラケット `［］` を追加（`width.Widen` による変換後も正しく除去）
- Kagome が既知+未知カタカナを1トークンに結合する問題に対し、最長一致分割（`splitUnknownKatakana`）で対処

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `haiku.go` | `normalizeText`, `splitUnknownKatakana` 追加。`reKana` に `ー` 追加。`reIgnoreText` に `［］` 追加。`MatchWithOpt`/`FindWithOpt` に正規化・再分割ステップ追加。`FindWithOpt` で `origSurfaces` マッピングにより元表記を保持 |
| `haiku_test.go` | カタカナ検出、半角対応、元表記保持、未知語スキップ防止、Kagome結合分割、全角ブラケットのテスト追加 |
| `go.mod` | `golang.org/x/text` を direct dependency に変更 |

## Test plan
- [x] 既存の俳句/短歌テスト（`testdata/*.good`, `testdata/*.bad`）が全て通ること
- [x] 既存のカタカナ結合テスト（トークン配列破損防止）が通ること
- [x] 未知カタカナ語を含むテキストで偽陽性が発生しないこと
- [x] 全角/半角/混合カタカナで俳句が検出されること
- [x] 半角入力時に結果が半角表記で返されること
- [x] ASCII/全角ブラケットが正しく無視されること
- [x] Kagome が結合したカタカナが分割されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)