### PR TITLE
fix: normalizeText の nfcToOrig マッピングで範囲外アクセスを修正

### DIFF
--- a/haiku.go
+++ b/haiku.go
@@ -143,12 +143,15 @@ func normalizeText(orig string) (string, []int) {
 		nfcToOrig[ni] = wi
 		if wi < len(wideRunes) && wideRunes[wi] == nfcRunes[ni] {
 			wi++
-		} else {
+		} else if wi < len(wideRunes) {
 			wi++ // base character
 			for wi < len(wideRunes) && unicode.Is(unicode.Mn, wideRunes[wi]) {
 				wi++
 			}
 		}
+	}
+	if wi > len(wideRunes) {
+		wi = len(wideRunes)
 	}
 	nfcToOrig[len(nfcRunes)] = wi
 

--- a/haiku_test.go
+++ b/haiku_test.go
@@ -225,3 +225,23 @@ func containsSubstring(text, sub string) bool {
 	cleanText = strings.ReplaceAll(cleanText, "　", "")
 	return strings.Contains(cleanText, sub)
 }
+
+func TestFindWithOpt_HalfWidthDakutenLongTextNoPanic(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// 半角カタカナの濁点・半濁点を多数含む長文でpanicしないことを確認
+	// width.Widen + NFC でルーン数が変わるケース
+	texts := []string{
+		"ﾃﾞｨｽﾞﾆｰﾗﾝﾄﾞに行ったらﾊﾟﾚｰﾄﾞを見てﾎﾟｯﾌﾟｺｰﾝを食べてﾊﾞｽで帰ったけどﾎﾟｹｯﾄからﾁｹｯﾄが出てきたよ",
+		"ﾎﾟｹﾓﾝﾊﾞﾄﾙでﾋﾞｰﾀﾞﾏﾝがﾃﾞﾝﾘｭｳにﾊﾞﾁﾊﾞﾁやられたけどﾋﾟｶﾁｭｳのﾃﾞﾝｷｼｮｯｸで勝ったよ",
+		"ﾎﾞｸのﾊﾟｿｺﾝがﾌﾞﾙｰｽｸﾘｰﾝになってﾃﾞｰﾀがﾊﾞｸﾊﾂしたけどﾊﾞｯｸｱｯﾌﾟがあってﾎﾞｸは助かった",
+	}
+	for _, text := range texts {
+		// パニックしないことが主目的
+		_, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", text, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- 半角カタカナの濁点・半濁点を含む長文で `width.Widen` + `norm.NFC` によりルーン数が減少した際、`normalizeText` の else 分岐で `wi` が `len(wideRunes)` を超えて `origRunes` の範囲外アクセスで panic が発生していた
- else 分岐に `wi < len(wideRunes)` の境界チェックを追加し、末尾クランプも追加
- 半角濁点・半濁点を多数含む長文テキストの回帰テストを追加

## Test plan
- [x] 既存テスト全通過
- [x] 新規テスト `TestFindWithOpt_HalfWidthDakutenLongTextNoPanic` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)