### PR TITLE
fix: 未知英単語とアラビア数字による偽俳句検出を修正

### DIFF
--- a/haiku.go
+++ b/haiku.go
@@ -20,6 +20,7 @@ var (
 	reIgnoreText = regexp.MustCompile(`[\[\]［］「」『』、。？！]`)
 	reIgnoreChar = regexp.MustCompile(`[ァィゥェォャュョ]`)
 	reKana       = regexp.MustCompile(`^[ァ-ヶー]+$`)
+	reDigit      = regexp.MustCompile(`^[０-９]+$`)
 
 	globalDict *dict.Dict
 )
@@ -255,6 +256,9 @@ func MatchWithOpt(text string, rule []int, opt *Opt) bool {
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
 		c := tok.Features()
+		if reDigit.MatchString(tok.Surface) {
+			return false
+		}
 		var y string
 		if reKana.MatchString(tok.Surface) {
 			y = tok.Surface
@@ -414,7 +418,13 @@ func FindWithOpt(text string, rule []int, opt *Opt) ([]string, error) {
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
 		c := tok.Features()
-		if len(c) < 7 && !reKana.MatchString(tok.Surface) {
+		if (len(c) < 7 && !reKana.MatchString(tok.Surface)) || reDigit.MatchString(tok.Surface) {
+			if pos > 0 || r[0] != rule[0] {
+				pos = 0
+				ambigous = 0
+				sentence = ""
+				copy(r, rule)
+			}
 			continue
 		}
 		var y string

--- a/haiku_test.go
+++ b/haiku_test.go
@@ -245,3 +245,53 @@ func TestFindWithOpt_HalfWidthDakutenLongTextNoPanic(t *testing.T) {
 		}
 	}
 }
+
+// 辞書に存在しない英単語をスキップして離れたトークンが結合され
+// 偽の俳句が検出されるバグの回避を確認する
+func TestFindWithOpt_UnknownAlphabeticWordShouldResetState(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	texts := []string{
+		"apple carplay と android autoに対応してる",
+		"python frameworkでwebsite作ってdeployした",
+	}
+	for _, text := range texts {
+		result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", text, err)
+		}
+		if len(result) > 0 {
+			t.Errorf("expected no haiku for %q, got %v", text, result)
+		}
+	}
+}
+
+// アラビア数字が個別トークン化され各桁の発音で偽のモーラ数になるバグの回避を確認する
+func TestFindWithOpt_ArabicDigitsShouldResetState(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	texts := []string{
+		"15000文字はかかりそう",
+		"12345回やり直してみた",
+	}
+	for _, text := range texts {
+		result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", text, err)
+		}
+		if len(result) > 0 {
+			t.Errorf("expected no haiku for %q, got %v", text, result)
+		}
+	}
+}
+
+func TestMatchWithOpt_ArabicDigitsShouldNotMatch(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	if MatchWithOpt("15000文字はかかりそう", []int{5, 7, 5}, opts) {
+		t.Error("expected no match for text containing arabic digits")
+	}
+}


### PR DESCRIPTION
## Summary
- 未知の英単語（`carplay`, `android`等、features < 7の非カタカナトークン）が `continue` でスキップされ、離れたトークンが結合されて偽の俳句が検出されるバグを修正
- アラビア数字が各桁ごとに個別トークン化され、実際の読み（例: 15000→いちまんごせん）と異なるモーラ数で計算されることによる偽検出を修正

## Changes
- `reDigit` 正規表現（`^[０-９]+$`）を追加
- `FindWithOpt`: 未知非カタカナトークン・数字トークンに遭遇時、俳句構築中なら状態をリセット
- `MatchWithOpt`: 数字トークンを含むテキストは `false` を返す

## Test plan
- [x] 既存テスト全件 PASS
- [x] `TestFindWithOpt_UnknownAlphabeticWordShouldResetState`: 英単語混在テキストで偽検出しないことを確認
- [x] `TestFindWithOpt_ArabicDigitsShouldResetState`: 数字混在テキストで偽検出しないことを確認
- [x] `TestMatchWithOpt_ArabicDigitsShouldNotMatch`: Match でも数字を正しく拒否することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)