### PR TITLE
fix: splitUnknownKatakana で Search モードを使用し隣接カタカナ語の分割を修正

### DIFF
--- a/haiku.go
+++ b/haiku.go
@@ -169,7 +169,7 @@ func splitUnknownKatakana(t *tokenizer.Tokenizer, surface string) []tokenizer.To
 	if len(runes) <= 1 {
 		return nil
 	}
-	tokens := t.Tokenize(surface)
+	tokens := t.Analyze(surface, tokenizer.Search)
 	if len(tokens) <= 1 {
 		return nil
 	}

--- a/haiku_test.go
+++ b/haiku_test.go
@@ -287,6 +287,26 @@ func TestFindWithOpt_ArabicDigitsShouldResetState(t *testing.T) {
 	}
 }
 
+// Kagome が隣接するカタカナ語（既知＋未知）を1トークンに結合した場合に
+// Search モードで正しく分割され俳句が検出されることを確認
+func TestMatchWithOpt_AdjacentKatakanaShouldBeSplit(t *testing.T) {
+	opts := &Opt{
+		Dict: uni.Dict(),
+	}
+	// スペースなしの入力で「カプチーノアサシーノ」が1トークンになるケース
+	text := "カプチーノアサシーノ見るバレリーナ"
+	if !MatchWithOpt(text, []int{5, 7, 5}, opts) {
+		t.Errorf("expected %q to match 5-7-5", text)
+	}
+	result, err := FindWithOpt(text, []int{5, 7, 5}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Errorf("expected haiku to be found in %q, got none", text)
+	}
+}
+
 func TestMatchWithOpt_ArabicDigitsShouldNotMatch(t *testing.T) {
 	opts := &Opt{
 		Dict: uni.Dict(),


### PR DESCRIPTION
## Summary
- `splitUnknownKatakana` の再トークナイズを `t.Tokenize()` (Normal モード) から `t.Analyze(surface, tokenizer.Search)` (Search モード) に変更
- スペースなしの入力で Kagome が「カプチーノアサシーノ」のような既知＋未知カタカナ連結を1トークンとして返すケースで、Search モードにより既知語境界で正しく分割されるようになる
- 再現テスト `TestMatchWithOpt_AdjacentKatakanaShouldBeSplit` を追加

## Test plan
- [x] 新規テスト `TestMatchWithOpt_AdjacentKatakanaShouldBeSplit` が通ること
- [x] 既存テスト全件パス (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)